### PR TITLE
🔒 Verify AltServer binary integrity

### DIFF
--- a/install_altstore.ps1
+++ b/install_altstore.ps1
@@ -28,9 +28,19 @@ Read-Host
 $altStoreUrl = "https://cdn.altstore.io/file/altstore/altinstaller.zip"
 $zipPath = "$env:TEMP\altinstaller.zip"
 $extractPath = "$env:TEMP\AltInstaller"
+$expectedHash = "E0423A6036E8D34F051D60C91705805ED68B1A7D586F791C45543067E2E36C0A"
 
 Write-Host "Step 2: Downloading AltServer..." -ForegroundColor Cyan
 Invoke-WebRequest -Uri $altStoreUrl -OutFile $zipPath
+
+Write-Host "Verifying AltServer download..." -ForegroundColor Cyan
+$fileHash = Get-FileHash -Path $zipPath -Algorithm SHA256
+if ($fileHash.Hash -ne $expectedHash) {
+    Write-Error "Hash verification failed! Expected: $expectedHash, Actual: $($fileHash.Hash)"
+    Remove-Item -Path $zipPath -Force
+    exit 1
+}
+Write-Host "Hash verification successful." -ForegroundColor Green
 
 Write-Host "Extracting AltServer..." -ForegroundColor Cyan
 if (Test-Path $extractPath) { Remove-Item -Path $extractPath -Recurse -Force }


### PR DESCRIPTION
This PR addresses a security vulnerability in `install_altstore.ps1` where `altinstaller.zip` was downloaded and executed without verification.

### 🎯 What
- Added SHA256 hash verification for the downloaded `altinstaller.zip`.
- Defined the expected hash as `E0423A6036E8D34F051D60C91705805ED68B1A7D586F791C45543067E2E36C0A`.

### ⚠️ Risk
- Without verification, a compromised download server or a man-in-the-middle attack could replace the installer with a malicious binary, leading to potential system compromise.
- The script would blindly extract and execute the tampered file.

### 🛡️ Solution
- The script now calculates the SHA256 hash of the downloaded file.
- It compares the calculated hash against the hardcoded expected hash.
- If the hashes do not match, the script deletes the file and exits with an error, preventing execution.


---
*PR created automatically by Jules for task [18395326512092203316](https://jules.google.com/task/18395326512092203316) started by @YvigUnderscore*