### PR TITLE
Refactor: Remove redundant quaternionFromMatrix wrapper

### DIFF
--- a/DIETCapture/Services/ExportService.swift
+++ b/DIETCapture/Services/ExportService.swift
@@ -219,7 +219,7 @@ final class ExportService {
         let position = pose.position
         
         // Extract quaternion from rotation matrix
-        let quat = quaternionFromMatrix(pose.rotation3x3)
+        let quat = simd_quatf(pose.rotation3x3)
         
         let line = "\(timestamp), \(frame), \(position.x), \(position.y), \(position.z), \(quat.vector.x), \(quat.vector.y), \(quat.vector.z), \(quat.vector.w)\n"
         handle.write(line.data(using: .utf8)!)
@@ -229,12 +229,6 @@ final class ExportService {
         odometryFileHandle?.closeFile()
         odometryFileHandle = nil
         hasWrittenOdometryHeader = false
-    }
-    
-    // MARK: - Quaternion from Rotation Matrix
-    
-    private func quaternionFromMatrix(_ R: simd_float3x3) -> simd_quatf {
-        return simd_quatf(R)
     }
     
     // MARK: - Depth Map Export (16-bit PNG, millimeters)


### PR DESCRIPTION
Removed a redundant wrapper function `quaternionFromMatrix` in `DIETCapture/Services/ExportService.swift` and replaced its usage with direct `simd_quatf` initialization. This improves code clarity by removing unnecessary indirection. Verified by manual inspection as no test suite is available for this iOS codebase in the current environment.

---
*PR created automatically by Jules for task [7783052889181393154](https://jules.google.com/task/7783052889181393154) started by @YvigUnderscore*