### PR TITLE
🧹 Restrict Visibility of jetColormap

### DIFF
--- a/DIETCapture/Utils/DepthMapProcessor.swift
+++ b/DIETCapture/Utils/DepthMapProcessor.swift
@@ -65,7 +65,7 @@ final class DepthMapProcessor {
     // MARK: - Jet Colormap
     
     /// Converts a depth value (normalized 0-1) to RGB using the jet colormap.
-    static func jetColormap(_ value: Float) -> (r: Float, g: Float, b: Float) {
+    private static func jetColormap(_ value: Float) -> (r: Float, g: Float, b: Float) {
         let v = max(0, min(1, value))
         
         var r: Float = 0, g: Float = 0, b: Float = 0


### PR DESCRIPTION
🎯 **What:** Restricted visibility of `jetColormap` helper method in `DepthMapProcessor.swift`.
💡 **Why:** `jetColormap` is a helper function used only within `DepthMapProcessor`. Making it `private` improves encapsulation and signals intended usage.
✅ **Verification:** Verified via static analysis (grep) that no other files reference this method.
✨ **Result:** Improved code health and maintainability.

---
*PR created automatically by Jules for task [689642628856565051](https://jules.google.com/task/689642628856565051) started by @YvigUnderscore*