### PR TITLE
🧹 Improve error handling for depth and confidence map export

### DIFF
--- a/DIETCapture/ViewModels/CaptureViewModel.swift
+++ b/DIETCapture/ViewModels/CaptureViewModel.swift
@@ -269,14 +269,22 @@ final class CaptureViewModel {
                let depthCopy = DepthMapProcessor.copyDepthMap(depthMap),
                let url = self.session.depthURL(for: frameIndex) {
                 DepthMapProcessor.filterByDistance(depthCopy, maxDistance: self.settings.lidar.maxDistance)
-                self.exportService.saveDepthMap16BitPNG(depthCopy, to: url)
+                self.exportService.saveDepthMap16BitPNG(depthCopy, to: url) { result in
+                    if case .failure(let error) = result {
+                        print("[CaptureVM] Depth export error: \(error)")
+                    }
+                }
             }
             
             // Save confidence map
             if let confMap = frame.sceneDepth?.confidenceMap,
                let confCopy = DepthMapProcessor.copyDepthMap(confMap),
                let url = self.session.confidenceURL(for: frameIndex) {
-                self.exportService.saveConfidenceMap(confCopy, to: url)
+                self.exportService.saveConfidenceMap(confCopy, to: url) { result in
+                    if case .failure(let error) = result {
+                        print("[CaptureVM] Confidence export error: \(error)")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR addresses a code health issue in `DIETCapture/Services/ExportService.swift` where depth and confidence map export failures were silently ignored.

**Changes:**
1.  Modified `saveDepthMap16BitPNG` and `saveConfidenceMap` to accept an optional completion handler.
2.  Implemented proper error propagation using `Result<Void, Error>`.
3.  Updated `CaptureViewModel` to log any errors that occur during export.

**Verification:**
- Verified that `ExportService.swift` contains the `ExportError` enum.
- Verified that `CVPixelBufferLockBaseAddress` is correctly used in the asynchronous block.
- Confirmed that the call sites in `CaptureViewModel.swift` are updated to match the new function signatures.
- Note: Due to environment limitations (Linux), automated tests involving iOS frameworks could not be run. Verification relied on manual code analysis and review.

---
*PR created automatically by Jules for task [10271559091890802359](https://jules.google.com/task/10271559091890802359) started by @YvigUnderscore*