### PR TITLE
Refactor duplicate video URL logic

### DIFF
--- a/DIETCapture/Models/CaptureModels.swift
+++ b/DIETCapture/Models/CaptureModels.swift
@@ -253,9 +253,11 @@ struct RecordedSession: Identifiable, Hashable {
     let frameCount: Int
     let hasDepth: Bool
     let hasConfidence: Bool
-    let hasVideo: Bool
+    let videoURL: URL?
     let thumbnailURL: URL?
     
+    var hasVideo: Bool { videoURL != nil }
+
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
     static func == (lhs: RecordedSession, rhs: RecordedSession) -> Bool { lhs.id == rhs.id }
 }

--- a/DIETCapture/Models/CaptureSession.swift
+++ b/DIETCapture/Models/CaptureSession.swift
@@ -139,9 +139,15 @@ final class CaptureSession {
             let videoFileMp4 = dir.appendingPathComponent("rgb.mp4")
             let videoFileMov = dir.appendingPathComponent("rgb.mov")
             
+            var videoURL: URL?
+            if fm.fileExists(atPath: videoFileMp4.path) {
+                videoURL = videoFileMp4
+            } else if fm.fileExists(atPath: videoFileMov.path) {
+                videoURL = videoFileMov
+            }
+
             let depthFiles = (try? fm.contentsOfDirectory(atPath: depthDir.path))?.filter { $0.hasSuffix(".png") } ?? []
             let hasConf = fm.fileExists(atPath: confDir.path)
-            let hasVideo = fm.fileExists(atPath: videoFileMp4.path) || fm.fileExists(atPath: videoFileMov.path)
             
             let creationDate = (try? fm.attributesOfItem(atPath: dir.path))?[.creationDate] as? Date ?? Date()
             
@@ -156,7 +162,7 @@ final class CaptureSession {
                 frameCount: depthFiles.count,
                 hasDepth: !depthFiles.isEmpty,
                 hasConfidence: hasConf,
-                hasVideo: hasVideo,
+                videoURL: videoURL,
                 thumbnailURL: thumbURL
             ))
         }

--- a/DIETCapture/Views/MediaLibraryView.swift
+++ b/DIETCapture/Views/MediaLibraryView.swift
@@ -7,17 +7,6 @@ import SwiftUI
 import AVKit
 import AVFoundation
 
-// MARK: - Shared Helper
-
-/// Find the video file in a session directory (supports both .mp4 and .mov)
-private func findVideoURL(in directory: URL) -> URL? {
-    let mp4 = directory.appendingPathComponent("rgb.mp4")
-    if FileManager.default.fileExists(atPath: mp4.path) { return mp4 }
-    let mov = directory.appendingPathComponent("rgb.mov")
-    if FileManager.default.fileExists(atPath: mov.path) { return mov }
-    return nil
-}
-
 struct MediaLibraryView: View {
     @State private var sessions: [RecordedSession] = []
     @State private var selectedSession: RecordedSession?
@@ -195,8 +184,7 @@ struct SessionCardView: View {
     // MARK: - Thumbnail Generation
     
     private func generateThumbnail(for session: RecordedSession) async -> UIImage? {
-        let videoURL = findVideoURL(in: session.directory)
-        guard let videoURL = videoURL else { return nil }
+        guard let videoURL = session.videoURL else { return nil }
         
         let asset = AVAsset(url: videoURL)
         let generator = AVAssetImageGenerator(asset: asset)
@@ -429,7 +417,7 @@ struct SessionDetailView: View {
     }
     
     private func setupVideoPlayer() {
-        if let videoURL = findVideoURL(in: session.directory) {
+        if let videoURL = session.videoURL {
             player = AVPlayer(url: videoURL)
         }
     }


### PR DESCRIPTION
This change centralizes the logic for finding the video file associated with a recorded session. Previously, `MediaLibraryView` had a private helper function `findVideoURL` that duplicated logic found partially in `CaptureSession`. By moving this logic to the model layer (`RecordedSession` and `CaptureSession`), we improve maintainability and ensure consistency.

**Verification:**
- Verified that `RecordedSession` struct is updated correctly.
- Verified that `CaptureSession.listSessions` prioritizes `.mp4` and then `.mov` correctly.
- Verified that `MediaLibraryView` usages are updated and the helper function is removed.
- Code review confirmed the changes are correct and safe.

---
*PR created automatically by Jules for task [16719667399125109941](https://jules.google.com/task/16719667399125109941) started by @YvigUnderscore*