### PR TITLE
🔒 Fix sensitive information exposure in install_altstore.sh

### DIFF
--- a/install_altstore.sh
+++ b/install_altstore.sh
@@ -129,20 +129,23 @@ echo -e "${GREEN}Device detected:${NC} $UDID"
 
 echo -e "${YELLOW}Starting AltServer...${NC}"
 
-ADB_ARGS="-u $UDID -a $APPLE_ID -p $APPLE_PASSWORD"
+ADB_ARGS="-u $UDID -a $APPLE_ID"
 
 if [ "$MODE" == "1" ] && [ ! -z "$IPA_PATH" ]; then
     echo "Installing App: $IPA_PATH"
     echo "Please keep your device UNLOCKED."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS "$IPA_PATH"
+    sudo -v
+    printf '%s\n' "$APPLE_PASSWORD" | sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS "$IPA_PATH"
 elif [ "$MODE" == "1" ] && [ -z "$IPA_PATH" ]; then
     echo -e "${RED}Cannot install directly: No IPA file found.${NC}"
     echo "Switching to Server Mode..."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
+    sudo -v
+    printf '%s\n' "$APPLE_PASSWORD" | sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
 else
     echo "Starting Server Mode..."
     echo "Keep this window open. On your iPhone, open AltStore -> My Apps -> + -> Select the IPA."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
+    sudo -v
+    printf '%s\n' "$APPLE_PASSWORD" | sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
 fi
 
 echo ""


### PR DESCRIPTION
This PR fixes a security vulnerability where the Apple ID password was passed as a command-line argument to `AltServer`, making it visible to other users on the system via `ps` or `/proc`.

The fix involves:
1.  Removing `-p $APPLE_PASSWORD` from `ADB_ARGS`.
2.  Piping the password to `AltServer`'s standard input using `printf '%s\n' "$APPLE_PASSWORD" | sudo ...`.
3.  Adding `sudo -v` before the command to ensure `sudo` credentials are fresh and prevent `sudo` from consuming the piped password.

This change ensures that sensitive credentials are not exposed in the process list.
Verified using a mock script that the password is correctly passed via stdin and not arguments.

---
*PR created automatically by Jules for task [4591461556903145454](https://jules.google.com/task/4591461556903145454) started by @YvigUnderscore*