### PR TITLE
🔒 Fix Improper Quoting of Shell Variables in install_altstore.sh

### DIFF
--- a/install_altstore.sh
+++ b/install_altstore.sh
@@ -129,20 +129,20 @@ echo -e "${GREEN}Device detected:${NC} $UDID"
 
 echo -e "${YELLOW}Starting AltServer...${NC}"
 
-ADB_ARGS="-u $UDID -a $APPLE_ID -p $APPLE_PASSWORD"
+ADB_ARGS=(-u "$UDID" -a "$APPLE_ID" -p "$APPLE_PASSWORD")
 
 if [ "$MODE" == "1" ] && [ ! -z "$IPA_PATH" ]; then
     echo "Installing App: $IPA_PATH"
     echo "Please keep your device UNLOCKED."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS "$IPA_PATH"
+    sudo ALTSERVER_ANISETTE_SERVER="$ALTSERVER_ANISETTE_SERVER" "$ALTSERVER_BIN" "${ADB_ARGS[@]}" "$IPA_PATH"
 elif [ "$MODE" == "1" ] && [ -z "$IPA_PATH" ]; then
     echo -e "${RED}Cannot install directly: No IPA file found.${NC}"
     echo "Switching to Server Mode..."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
+    sudo ALTSERVER_ANISETTE_SERVER="$ALTSERVER_ANISETTE_SERVER" "$ALTSERVER_BIN" "${ADB_ARGS[@]}"
 else
     echo "Starting Server Mode..."
     echo "Keep this window open. On your iPhone, open AltStore -> My Apps -> + -> Select the IPA."
-    sudo ALTSERVER_ANISETTE_SERVER=$ALTSERVER_ANISETTE_SERVER "$ALTSERVER_BIN" $ADB_ARGS
+    sudo ALTSERVER_ANISETTE_SERVER="$ALTSERVER_ANISETTE_SERVER" "$ALTSERVER_BIN" "${ADB_ARGS[@]}"
 fi
 
 echo ""


### PR DESCRIPTION
Locked Security Vulnerability Fix Task

**What:** Fixed Improper Quoting of Shell Variables vulnerability in `install_altstore.sh`.

**Risk:** The previous implementation used unquoted `$ADB_ARGS` variable expansion, which could lead to argument splitting if arguments (like `APPLE_PASSWORD`) contained spaces or special characters. This could cause installation failure or unintended command execution.

**Solution:**
- Converted `ADB_ARGS` to a Bash array `ADB_ARGS=(-u "$UDID" ...)` to correctly handle multiple arguments.
- Used array expansion `"${ADB_ARGS[@]}"` when invoking `AltServer`.
- Added quotes to `ALTSERVER_ANISETTE_SERVER` assignment to prevent word splitting.
- Verified the fix with a reproduction script using mock executables, confirming that passwords with spaces are correctly passed as single arguments.

---
*PR created automatically by Jules for task [1753705540308903941](https://jules.google.com/task/1753705540308903941) started by @YvigUnderscore*